### PR TITLE
Fixed a bug with "Switch lesson" button

### DIFF
--- a/src/plm/core/ui/action/SwitchLesson.java
+++ b/src/plm/core/ui/action/SwitchLesson.java
@@ -22,8 +22,8 @@ public class SwitchLesson extends AbstractGameAction implements
 	
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		new ChooseLessonDialog();
 		MainFrame.getInstance().setVisible(false);
+		new ChooseLessonDialog();
 	}
 
 	@Override


### PR DESCRIPTION
I noticed a bug where you could press the "Switch lesson" button multiple times before the window was set invisible, making it create multiple dialogs. I just switched the two lines, setting the main frame invisible BEFORE creating the dialog, seems like fixing the bug.